### PR TITLE
dev env: add upper version constraint for importlib-metadata to keep compatibility with python3.5

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,8 @@ pytest = "*"
 pytest-cov = "*"
 
 # python3.5 compatibility
+# https://github.com/python/importlib_metadata/commit/107f9029fd5807c6579b881db19e11a0488f0675
+importlib-metadata = "<3"
 isort = "<5"
 # workaround https://github.com/pytest-dev/pytest/issues/3953
 pathlib2 = {version = "*", markers="python_version < '3.6'"}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f8caad99976835d7f8a237785d975a0bea63d3c0df9fe048394b4f49e339b615"
+            "sha256": "1d94dac93d9877f0c605ff14838858176d2ad2709d174d2cab0803a587771a2e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -127,10 +127,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:77a540690e24b0305878c37ffd421785a6f7e53c8b5720d211b211de8d0e95da",
-                "sha256:cefa1a2f919b866c5beb7c9f7b0ebb4061f30a8a9bf16d609b000e2dfaceb9c3"
+                "sha256:030f3b1bdb823ecbe4a9659e14cc861ce5af403fe99863bae173ec5fe00ab132",
+                "sha256:caeee3603f5dcf567864d1be9b839b0bcfdf1383e3e7be33ce2dead8144ff19c"
             ],
-            "version": "==2.0.0"
+            "index": "pypi",
+            "version": "==2.1.0"
         },
         "iniconfig": {
             "hashes": [


### PR DESCRIPTION
https://github.com/fphammerle/acpi-backlight/commit/cf4ab276b64ba7a2fe0667642410e1762c1e4f16